### PR TITLE
Public parameters pre-serialization & caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "ahash",
- "base64 0.13.0",
+ "base64 0.13.1",
  "bitflags",
  "brotli",
  "bytes 1.1.0",
@@ -206,7 +206,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "actix-web",
- "base64 0.13.0",
+ "base64 0.13.1",
  "futures-core",
  "futures-util",
  "pin-project-lite 0.2.7",
@@ -328,9 +328,9 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64ct"
@@ -1364,6 +1364,7 @@ dependencies = [
  "actix-web",
  "actix-web-httpauth",
  "arrayref",
+ "base64 0.13.1",
  "clap 3.0.10",
  "futures",
  "futures-util",
@@ -1376,6 +1377,7 @@ dependencies = [
  "serde",
  "serde_json",
  "subtle",
+ "twox-hash",
 ]
 
 [[package]]
@@ -1440,7 +1442,7 @@ version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "012bb02250fdd38faa5feee63235f7a459974440b9b57593822414c31f92839e"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "pem",
  "ring",
  "serde",
@@ -1844,7 +1846,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -2121,7 +2123,7 @@ version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "bytes 0.5.6",
  "encoding_rs",
  "futures-core",
@@ -2158,7 +2160,7 @@ version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "bytes 1.1.0",
  "encoding_rs",
  "futures-core",
@@ -2487,6 +2489,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2794,6 +2802,17 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if 1.0.0",
+ "rand",
+ "static_assertions",
+]
 
 [[package]]
 name = "typenum"

--- a/irmaseal-pkg/Cargo.toml
+++ b/irmaseal-pkg/Cargo.toml
@@ -23,6 +23,8 @@ reqwest = "0.11.10"
 serde = "*"
 serde_json = "1.0.68"
 subtle = "2.1.1"
+twox-hash = "1.6.3"
+base64 = "0.13.1"
 
 [dependencies.clap]
 features = ["derive"]

--- a/irmaseal-pkg/src/handlers/parameters.rs
+++ b/irmaseal-pkg/src/handlers/parameters.rs
@@ -1,21 +1,35 @@
+use actix_http::header::Header;
 use actix_web::{
-    http::header::{CacheControl, CacheDirective, ContentType, ETag, LastModified},
+    http::header::{
+        CacheControl, CacheDirective, ContentType, ETag, IfModifiedSince, IfNoneMatch, LastModified,
+    },
     web::Data,
-    HttpResponse, Responder,
+    HttpRequest, HttpResponse, Responder,
 };
 
 use crate::server::ParametersData;
 
-pub async fn parameters(pd: Data<ParametersData>) -> impl Responder
+pub async fn parameters(req: HttpRequest, pd: Data<ParametersData>) -> impl Responder
 where
 {
-    HttpResponse::Ok()
-        .insert_header(CacheControl(vec![
-            CacheDirective::Public,
-            CacheDirective::NoCache,
-        ]))
-        .insert_header(ETag(pd.etag.clone()))
-        .insert_header(LastModified(pd.last_modified.into()))
-        .content_type(ContentType::json())
-        .body(pd.pp.clone())
+    let if_none_match = IfNoneMatch::parse(&req);
+    let if_modified_since = IfModifiedSince::parse(&req);
+
+    match (if_none_match, if_modified_since) {
+        (Ok(IfNoneMatch::Items(ref tags)), ..) if tags.iter().any(|t| t.strong_eq(&pd.etag)) => {
+            HttpResponse::NotModified().finish()
+        }
+        (.., Ok(IfModifiedSince(ref since))) if &pd.last_modified <= since => {
+            HttpResponse::NotModified().finish()
+        }
+        _ => HttpResponse::Ok()
+            .insert_header(CacheControl(vec![
+                CacheDirective::Public,
+                CacheDirective::NoCache,
+            ]))
+            .insert_header(ETag(pd.etag.clone()))
+            .insert_header(LastModified(pd.last_modified))
+            .content_type(ContentType::json())
+            .body(pd.pp.clone()),
+    }
 }

--- a/irmaseal-pkg/src/server.rs
+++ b/irmaseal-pkg/src/server.rs
@@ -1,24 +1,18 @@
-use std::str::FromStr;
-use std::time::SystemTime;
-
-use actix_http::header::HttpDate;
-use actix_web::http::header::EntityTag;
-use irmaseal_core::kem::cgw_kv::CGWKV;
-use irmaseal_core::kem::IBKEM;
-use irmaseal_core::{api::Parameters, PublicKey};
-
 use crate::handlers;
+use crate::middleware::irma::{IrmaAuth, IrmaAuthType};
 use crate::opts::*;
 use crate::util::*;
 use actix_cors::Cors;
+use actix_http::header::HttpDate;
+use actix_web::http::header::EntityTag;
 use actix_web::{
     http::header,
     web,
     web::{resource, scope, Data},
     App, HttpServer,
 };
-
-use crate::middleware::irma::{IrmaAuth, IrmaAuthType};
+use irmaseal_core::kem::cgw_kv::CGWKV;
+use irmaseal_core::kem::IBKEM;
 
 #[derive(Clone)]
 pub struct MasterKeyPair<K: IBKEM> {
@@ -26,10 +20,16 @@ pub struct MasterKeyPair<K: IBKEM> {
     pub sk: K::Sk,
 }
 
+/// Precomputed parameter data.
 #[derive(Clone)]
 pub struct ParametersData {
+    /// Pre-serialized public parameters (JSON).
     pub pp: String,
+
+    /// Last modified.
     pub last_modified: HttpDate,
+
+    /// Etag.
     pub etag: EntityTag,
 }
 
@@ -48,28 +48,7 @@ pub async fn exec(server_opts: ServerOpts) {
         sk: cgwkv_read_sk(&secret).expect("cannot read secret key"),
     };
 
-    // Precompute the serialized public parameters.
-    let pp = serde_json::to_string(&Parameters::<CGWKV> {
-        format_version: 0x00,
-        public_key: PublicKey(kp.pk),
-    })
-    .expect("could not serialize public parameters");
-
-    // Also compute cache headers.
-    let modified_raw: HttpDate = match std::fs::metadata(&public).map(|m| m.modified()) {
-        Ok(Ok(t)) => t,
-        _ => SystemTime::now(),
-    }
-    .into();
-    let last_modified = HttpDate::from_str(&modified_raw.to_string()).unwrap();
-
-    let etag = EntityTag::new_strong(xxhash64(pp.as_bytes()));
-
-    let pd = ParametersData {
-        pp,
-        last_modified,
-        etag,
-    };
+    let pd = ParametersData::new(&kp.pk, Some(&public));
 
     HttpServer::new(move || {
         App::new()
@@ -131,6 +110,7 @@ mod tests {
     use irmaseal_core::api::{KeyResponse, Parameters};
     use irmaseal_core::{Attribute, Policy};
     use rand::thread_rng;
+    use std::time::SystemTime;
 
     fn now() -> u64 {
         SystemTime::now()
@@ -147,20 +127,7 @@ mod tests {
         let mut rng = thread_rng();
         let (pk, sk) = CGWKV::setup(&mut rng);
 
-        // Precompute the serialized public parameters.
-        let pp = serde_json::to_string(&Parameters::<CGWKV> {
-            format_version: 0x00,
-            public_key: PublicKey(pk),
-        })
-        .expect("could not serialize public parameters");
-        let last_modified = SystemTime::now();
-        let etag = EntityTag::new_strong(xxhash64(pp.as_bytes()));
-
-        let pd = ParametersData {
-            pp,
-            last_modified,
-            etag,
-        };
+        let pd = ParametersData::new(&pk, None);
 
         // Create a simple setup with a pk endpoint and a key service without authentication.
         let app = test::init_service(
@@ -188,9 +155,16 @@ mod tests {
     async fn test_get_parameters() {
         let (app, pk, _) = default_setup().await;
 
-        let req = test::TestRequest::get().uri("/v2/parameters").to_request();
-        let kr: Parameters<CGWKV> = test::call_and_read_body_json(&app, req).await;
+        let resp = test::TestRequest::get()
+            .uri("/v2/parameters")
+            .send_request(&app)
+            .await;
 
+        assert!(resp.headers().contains_key("last-modified"));
+        assert!(resp.headers().contains_key("cache-control"));
+        assert!(resp.headers().contains_key("etag"));
+
+        let kr: Parameters<CGWKV> = test::read_body_json(resp).await;
         assert_eq!(&kr.public_key.0, &pk);
         assert_eq!(kr.format_version, 0x00);
     }

--- a/irmaseal-pkg/src/server.rs
+++ b/irmaseal-pkg/src/server.rs
@@ -1,5 +1,9 @@
+use std::time::SystemTime;
+
+use actix_web::http::header::EntityTag;
 use irmaseal_core::kem::cgw_kv::CGWKV;
 use irmaseal_core::kem::IBKEM;
+use irmaseal_core::{api::Parameters, PublicKey};
 
 use crate::handlers;
 use crate::opts::*;
@@ -20,6 +24,13 @@ pub struct MasterKeyPair<K: IBKEM> {
     pub sk: K::Sk,
 }
 
+#[derive(Clone)]
+pub struct ParametersData {
+    pub pp: String,
+    pub last_modified: SystemTime,
+    pub etag: EntityTag,
+}
+
 #[actix_rt::main]
 pub async fn exec(server_opts: ServerOpts) {
     let ServerOpts {
@@ -31,8 +42,29 @@ pub async fn exec(server_opts: ServerOpts) {
     } = server_opts;
 
     let kp = MasterKeyPair::<CGWKV> {
-        pk: cgwkv_read_pk(public).unwrap(),
-        sk: cgwkv_read_sk(secret).unwrap(),
+        pk: cgwkv_read_pk(&public).expect("cannot read public key"),
+        sk: cgwkv_read_sk(&secret).expect("cannot read secret key"),
+    };
+
+    // Precompute the serialized public parameters.
+    let pp = serde_json::to_string(&Parameters::<CGWKV> {
+        format_version: 0x00,
+        public_key: PublicKey(kp.pk),
+    })
+    .expect("could not serialize public parameters");
+
+    // Also compute cache headers.
+    let last_modified = match std::fs::metadata(&public).map(|m| m.modified()) {
+        Ok(Ok(t)) => t,
+        _ => SystemTime::now(),
+    };
+
+    let etag = EntityTag::new_strong(xxhash64(pp.as_bytes()));
+
+    let pd = ParametersData {
+        pp,
+        last_modified,
+        etag,
     };
 
     HttpServer::new(move || {
@@ -43,6 +75,7 @@ pub async fn exec(server_opts: ServerOpts) {
                     .allowed_methods(vec!["GET", "POST"])
                     .allowed_header(header::CONTENT_TYPE)
                     .allowed_header(header::AUTHORIZATION)
+                    .allowed_header(header::ETAG)
                     .allowed_header("X-Postguard-Client-Version")
                     .max_age(86400),
             )
@@ -51,8 +84,8 @@ pub async fn exec(server_opts: ServerOpts) {
                 scope("/v2")
                     .service(
                         resource("/parameters")
-                            .app_data(Data::new(kp.pk))
-                            .route(web::get().to(handlers::parameters::<CGWKV>)),
+                            .app_data(Data::new(pd.clone()))
+                            .route(web::get().to(handlers::parameters)),
                     )
                     .service(
                         scope("/{_:(irma|request)}")
@@ -96,7 +129,7 @@ mod tests {
     use rand::thread_rng;
 
     fn now() -> u64 {
-        std::time::SystemTime::now()
+        SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs()
@@ -110,14 +143,29 @@ mod tests {
         let mut rng = thread_rng();
         let (pk, sk) = CGWKV::setup(&mut rng);
 
+        // Precompute the serialized public parameters.
+        let pp = serde_json::to_string(&Parameters::<CGWKV> {
+            format_version: 0x00,
+            public_key: PublicKey(pk),
+        })
+        .expect("could not serialize public parameters");
+        let last_modified = SystemTime::now();
+        let etag = EntityTag::new_strong(xxhash64(pp.as_bytes()));
+
+        let pd = ParametersData {
+            pp,
+            last_modified,
+            etag,
+        };
+
         // Create a simple setup with a pk endpoint and a key service without authentication.
         let app = test::init_service(
             App::new().service(
                 scope("/v2")
                     .service(
                         resource("/parameters")
-                            .app_data(Data::new(pk))
-                            .route(web::get().to(handlers::parameters::<CGWKV>)),
+                            .app_data(Data::new(pd))
+                            .route(web::get().to(handlers::parameters)),
                     )
                     .service(
                         resource("/key/{timestamp}")

--- a/irmaseal-pkg/src/util.rs
+++ b/irmaseal-pkg/src/util.rs
@@ -5,6 +5,16 @@ use irmaseal_core::Error;
 use paste::paste;
 use std::path::Path;
 
+use core::hash::Hasher;
+use twox_hash::XxHash64;
+
+pub(crate) fn xxhash64(x: &[u8]) -> String {
+    let mut h = XxHash64::with_seed(0);
+    h.write(&x);
+    let out = h.finish().to_be_bytes();
+    base64::encode(&out)
+}
+
 pub fn open_ct<T>(x: subtle::CtOption<T>) -> Option<T> {
     if bool::from(x.is_some()) {
         Some(x.unwrap())

--- a/irmaseal-pkg/src/util.rs
+++ b/irmaseal-pkg/src/util.rs
@@ -1,16 +1,22 @@
+use crate::server::ParametersData;
+use actix_http::header::HttpDate;
+use actix_web::http::header::EntityTag;
 use arrayref::array_ref;
+use core::hash::Hasher;
 use irmaseal_core::kem::{cgw_kv::CGWKV, IBKEM};
 use irmaseal_core::Compress;
 use irmaseal_core::Error;
+use irmaseal_core::{api::Parameters, PublicKey};
 use paste::paste;
+use serde::Serialize;
 use std::path::Path;
-
-use core::hash::Hasher;
+use std::str::FromStr;
+use std::time::SystemTime;
 use twox_hash::XxHash64;
 
 pub(crate) fn xxhash64(x: &[u8]) -> String {
     let mut h = XxHash64::with_seed(0);
-    h.write(&x);
+    h.write(x);
     let out = h.finish().to_be_bytes();
     base64::encode(&out)
 }
@@ -20,6 +26,44 @@ pub fn open_ct<T>(x: subtle::CtOption<T>) -> Option<T> {
         Some(x.unwrap())
     } else {
         None
+    }
+}
+
+impl ParametersData {
+    /// Precompute the public parameters, including cache headers.
+    pub(crate) fn new<K>(pk: &K::Pk, path: Option<&str>) -> ParametersData
+    where
+        K: IBKEM,
+        Parameters<K>: Serialize,
+    {
+        // Precompute the serialized public parameters.
+        let pp = serde_json::to_string(&Parameters::<K> {
+            format_version: 0x00,
+            public_key: PublicKey::<K>(*pk),
+        })
+        .expect("could not serialize public parameters");
+
+        // Also compute cache headers.
+
+        let modified_raw: HttpDate = if let Some(p) = path {
+            match std::fs::metadata(p).map(|m| m.modified()) {
+                Ok(Ok(t)) => t,
+                _ => SystemTime::now(),
+            }
+        } else {
+            SystemTime::now()
+        }
+        .into();
+
+        let last_modified = HttpDate::from_str(&modified_raw.to_string()).unwrap();
+
+        let etag = EntityTag::new_strong(xxhash64(pp.as_bytes()));
+
+        ParametersData {
+            pp,
+            last_modified,
+            etag,
+        }
     }
 }
 


### PR DESCRIPTION
This PR aims to make the public key end point (`/v2/parameters`) significantly faster.
It does so by:

1. pre-serializing the public parameters only once,
2. utilizing [If-None-Match](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match) and [If-Modified-Since](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Modified-Since) HTTP headers. No public key is transmitted if the resource is still fresh in the cache.